### PR TITLE
{legacy, parts}: plugins: kernel: add support for using the LLVM utilities

### DIFF
--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -154,6 +154,7 @@ setup accordingly.
 
 import logging
 import os
+import re
 import subprocess
 import sys
 from typing import Any, Dict, List, Optional, Set, cast
@@ -1265,7 +1266,8 @@ class KernelPlugin(plugins.Plugin):
         # check if we are using gcc or another compiler
         if self.options.kernel_compiler:
             # at the moment only clang is supported as alternative, warn otherwise
-            if self.options.kernel_compiler != "clang":
+            kernel_compiler = re.match(r"^clang(-\d+)?$", self.options.kernel_compiler)
+            if kernel_compiler is None:
                 logger.warning("Only other 'supported' compiler is clang")
                 logger.info("hopefully you know what you are doing")
             self.make_cmd.append(f'CC="{self.options.kernel_compiler}"')

--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -147,6 +147,11 @@ The following kernel-specific options are provided by this plugin:
       (boolean; default: True)
       controls if the snappy-dev PPA should be added to the system
 
+    - kernel-use-llvm
+      (boolean or string to specify version suffix; default: False)
+      Use the LLVM substitutes for the GNU binutils utilities. Set this to a
+      string (e.g. "-12") to use a specific version of the LLVM utilities.
+
 This plugin support cross compilation, for which plugin expects
 the build-environment is comfigured accordingly and has foreign architectures
 setup accordingly.
@@ -157,7 +162,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Dict, List, Optional, Set, cast
+from typing import Any, Dict, List, Optional, Set, cast, Union
 
 from craft_parts import infos, plugins
 from overrides import overrides
@@ -262,6 +267,7 @@ class KernelPluginProperties(plugins.PluginProperties, plugins.PluginModel):
     kernel_enable_zfs_support: bool = False
     kernel_enable_perf: bool = False
     kernel_add_ppa: bool = True
+    kernel_use_llvm: Union[bool, str] = False
 
     # part properties required by the plugin
     @root_validator
@@ -318,6 +324,23 @@ class KernelPlugin(plugins.Plugin):
             != self._part_info.project_info.target_arch
         ):
             self._cross_building = True
+        self._llvm_version = self._determine_llvm_version()
+
+    def _determine_llvm_version(self) -> Optional[str]:
+        if (
+            isinstance(self.options.kernel_use_llvm, bool)
+            and self.options.kernel_use_llvm
+        ):
+            return "1"
+        elif isinstance(self.options.kernel_use_llvm, str):
+            suffix = re.match(r"^-\d+$", self.options.kernel_use_llvm)
+            if suffix is None:
+                raise ValueError(
+                    f'kernel-use-llvm must match the format "-<version>" (e.g. "-12"), not "{self.options.kernel_use_llvm}"'
+                )
+            return self.options.kernel_use_llvm
+        # Not use LLVM utilities
+        return None
 
     def _init_build_env(self) -> None:
         # first get all the architectures, new v2 plugin is making life difficult
@@ -331,6 +354,7 @@ class KernelPlugin(plugins.Plugin):
 
         self._check_cross_compilation()
         self._set_kernel_targets()
+        self._set_llvm()
 
         # determine type of initrd
         snapd_snap_file_name = _SNAPD_SNAP_FILE.format(
@@ -393,6 +417,10 @@ class KernelPlugin(plugins.Plugin):
                 ["dtbs_install", "INSTALL_DTBS_PATH=${CRAFT_PART_INSTALL}/dtbs"]
             )
         self.make_install_targets.extend(self._get_fw_install_targets())
+
+    def _set_llvm(self) -> None:
+        if self._llvm_version is not None:
+            self.make_cmd.append(f'LLVM="{self._llvm_version}"')
 
     def _get_fw_install_targets(self) -> List[str]:
         if not self.options.kernel_with_firmware:
@@ -1392,6 +1420,16 @@ class KernelPlugin(plugins.Plugin):
         # add snappy ppa to get correct initrd tools
         if self.options.kernel_add_ppa:
             self._add_snappy_ppa()
+
+        if self._llvm_version is not None:
+            # Use the specified version suffix for the packages if it has been
+            # set by the user
+            suffix = self._llvm_version if self._llvm_version != "1" else ""
+            llvm_packages = [
+                "llvm",
+                "lld",
+            ]
+            build_packages |= set(f"{f}{suffix}" for f in llvm_packages)
 
         return build_packages
 

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -150,6 +150,7 @@ setup accordingly.
 
 import logging
 import os
+import re
 import subprocess
 import sys
 from typing import Any, Dict, List, Set
@@ -1282,7 +1283,8 @@ class KernelPlugin(PluginV2):
         # check if we are using gcc or another compiler
         if self.options.kernel_compiler:
             # at the moment only clang is supported as alternative, warn otherwise
-            if self.options.kernel_compiler != "clang":
+            kernel_compiler = re.match(r"^clang(-\d+)?$", self.options.kernel_compiler)
+            if kernel_compiler is None:
                 logger.warning("Only other 'supported' compiler is clang")
                 logger.info("hopefully you know what you are doing")
             self.make_cmd.append(f'CC="{self.options.kernel_compiler}"')

--- a/snapcraft_legacy/plugins/v2/kernel.py
+++ b/snapcraft_legacy/plugins/v2/kernel.py
@@ -143,6 +143,11 @@ The following kernel-specific options are provided by this plugin:
       (boolean; default: True)
       controls if the snappy-dev PPA should be added to the system
 
+    - kernel-use-llvm
+      (boolean or string to specify version suffix; default: False)
+      Use the LLVM substitutes for the GNU binutils utilities. Set this to a
+      string (e.g. "-12") to use a specific version of the LLVM utilities.
+
 This plugin support cross compilation, for which plugin expects
 the build-environment is comfigured accordingly and has foreign architectures
 setup accordingly.
@@ -153,7 +158,7 @@ import os
 import re
 import subprocess
 import sys
-from typing import Any, Dict, List, Set
+from typing import Any, Dict, List, Optional, Set
 
 from overrides import overrides
 
@@ -342,6 +347,10 @@ class KernelPlugin(PluginV2):
                     "type": "boolean",
                     "default": True,
                 },
+                "kernel-use-llvm": {
+                    "oneOf": [{"type": "boolean"}, {"type": "string"}],
+                    "default": False,
+                },
             },
         }
 
@@ -357,6 +366,23 @@ class KernelPlugin(PluginV2):
         self._cross_building = False
         if host_arch != self.target_arch:
             self._cross_building = True
+        self._llvm_version = self._determine_llvm_version()
+
+    def _determine_llvm_version(self) -> Optional[str]:
+        if (
+            isinstance(self.options.kernel_use_llvm, bool)
+            and self.options.kernel_use_llvm
+        ):
+            return "1"
+        elif isinstance(self.options.kernel_use_llvm, str):
+            suffix = re.match(r"^-\d+$", self.options.kernel_use_llvm)
+            if suffix is None:
+                raise ValueError(
+                    f'kernel-use-llvm must match the format "-<version>" (e.g. "-12"), not "{self.options.kernel_use_llvm}"'
+                )
+            return self.options.kernel_use_llvm
+        # Not use LLVM utilities
+        return None
 
     def _init_build_env(self) -> None:
         # first get all the architectures, new v2 plugin is making life difficult
@@ -370,6 +396,7 @@ class KernelPlugin(PluginV2):
 
         self._check_cross_compilation()
         self._set_kernel_targets()
+        self._set_llvm()
 
         # determine type of initrd
         snapd_snap_file_name = _SNAPD_SNAP_FILE.format(
@@ -451,6 +478,10 @@ class KernelPlugin(PluginV2):
                 ["dtbs_install", "INSTALL_DTBS_PATH=${SNAPCRAFT_PART_INSTALL}/dtbs"]
             )
         self.make_install_targets.extend(self._get_fw_install_targets())
+
+    def _set_llvm(self) -> None:
+        if self._llvm_version is not None:
+            self.make_cmd.append(f'LLVM="{self._llvm_version}"')
 
     def _get_fw_install_targets(self) -> List[str]:
         if not self.options.kernel_with_firmware:
@@ -1408,6 +1439,16 @@ class KernelPlugin(PluginV2):
         # add snappy ppa to get correct initrd tools
         if self.options.kernel_add_ppa:
             self._add_snappy_ppa()
+
+        if self._llvm_version is not None:
+            # Use the specified version suffix for the packages if it has been
+            # set by the user
+            suffix = self._llvm_version if self._llvm_version != "1" else ""
+            llvm_packages = [
+                "llvm",
+                "lld",
+            ]
+            build_packages |= set(f"{f}{suffix}" for f in llvm_packages)
 
         return build_packages
 


### PR DESCRIPTION
Add the new configuration value `kernel-use-llvm` to allow the use of the LLVM substitutes for the GNU binutils utilities. This can be set to either `True` or a string (e.g. "-12") to use a specific version of the LLVM utilities.

Additionally add support for using the clang compiler with a version suffix.