### PR TITLE
kernel plugin initramfs: don't copy extra-modules.conf

### DIFF
--- a/snapcraft/parts/plugins/kernel.py
+++ b/snapcraft/parts/plugins/kernel.py
@@ -861,14 +861,6 @@ class KernelPlugin(plugins.Plugin):
                     ],
                 ),
                 "done",
-                " ".join(
-                    [
-                        "cp",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/kernel-modules/extra-modules.conf",
-                        "${UC_INITRD_DEB}/usr/lib/ubuntu-core-initramfs/modules/main/extra-modules.conf",
-                    ],
-                ),
-                "",
             ],
         )
         firmware_dir = "${CRAFT_PART_INSTALL}/lib/firmware"


### PR DESCRIPTION
Fixes failure to copy due to non-existent source file. Source file no longer exists upstream, and intended target already exists. See https://github.com/snapcore/core-initrd/tree/main/modules

Don't know how relevant these are since I'm wanting to push to a fork, but here goes:
- [x] Have you followed the [guidelines for contributing](https://github.com/snapcore/snapcraft/blob/master/CONTRIBUTING.md)?
- [x] Have you signed the [CLA](http://www.ubuntu.com/legal/contributors/)?
- [x] Have you successfully run `./runtests.sh static`?
- [x] Have you successfully run `./runtests.sh tests/unit`?

-----
